### PR TITLE
replace black and ruff-lsp with ruff

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721016451,
-        "narHash": "sha256-Cypl9ORr5UjtBsbjXMTJRepTe362yNVrPrntUvHiTaw=",
+        "lastModified": 1726108120,
+        "narHash": "sha256-Ji5wO1lLG99grI0qCRb6FyRPpH9tfdfD1QP/r7IlgfM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a14c5d651cee9ed70f9cd9e83f323f1e531002db",
+        "rev": "111ed8812c10d7dc3017de46cbf509600c93f551",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,17 +25,14 @@
               with ps; [
                 graphviz
 
-                # dev tools
-                black
-
                 # debugger
                 pudb
               ]))
             gcc
             graphviz
 
-            # linter
-            ruff-lsp
+            # linter and formatter
+            ruff
           ];
           shellHook = ''
             export PYTHONPATH="$(realpath .):$(realpath ./interp_x86)"


### PR DESCRIPTION
- ruff-lsp is deprecated. `ruff server` is included in ruff now.
- removed black since ruff also does formatting
- also `nix flake update`
